### PR TITLE
stop resource name escaping container on resource view

### DIFF
--- a/ckanext/datawagovautheme/static/datawagovautheme.css
+++ b/ckanext/datawagovautheme/static/datawagovautheme.css
@@ -241,3 +241,11 @@ body {
 #debug-toggle {
  color: rgb(200, 200, 200);
 }
+
+/* Fix wrapping of label in list on resource page */
+.nav-item > a span {
+  white-space: nowrap;
+  overflow: hidden;
+  display: block;
+}
+


### PR DESCRIPTION
When on the dataset view (/dataset/<id>/resource/<id>/), the sidebar for 'resources' will run over into the 'Additional information' section. This fixes that up, by hiding overflow. Note this is already in the CKAN css, but only applies to the 'active' item (which seems to just be a mistake.)